### PR TITLE
Sync README, ROADMAP, and CLAUDE.md docs from DLaneAtElekta fork

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,183 @@
+# CLAUDE.md - Project Context for AI Assistants
+
+## Project Overview
+
+**SRODecoderRing** is a machine learning project that uses deep learning to infer rotation order from transformation matrices and Euler angles. The project specifically addresses the challenge of interpreting DICOM Spatial Registration Objects (SRO) in the context of radiotherapy image-guidance.
+
+The core problem: Given an SRO (Spatial Registration Object) and an offset, the ML model learns to recognize the input-output relationship to decode the meaning of rotation orders, which is particularly important for patient positioning in medical imaging.
+
+## Domain Context
+
+- **DICOM**: Digital Imaging and Communications in Medicine - the standard for medical imaging data
+- **SRO (Spatial Registration Object)**: DICOM objects that describe spatial transformations between coordinate systems
+- **Radiotherapy Context**: Accurate spatial transformations are critical for patient positioning and treatment delivery
+- **Rotation Order Problem**: Different conventions for applying rotations (e.g., XYZ vs ZYX) can lead to confusion and errors in patient positioning
+
+## Architecture
+
+This is a multi-language, multi-component project:
+
+### Components
+
+1. **Machine Learning Core** (Python)
+   - Deep Energy-Based Models (EBM) for learning rotation mappings
+   - PyTorch-based implementation with Lightning
+   - Training notebooks and scripts
+   - MCMC sampling for inference
+
+2. **Inference Engine** (F#)
+   - Production inference engine
+   - Consumes trained weights and model parameters
+   - Functional programming approach for reliability
+
+3. **User Interface** (C#/XAML)
+   - Desktop UI for interacting with the decoder
+   - WPF/XAML-based interface
+
+4. **Web Service** (Flask/Python)
+   - RESTful API for serving predictions
+   - Deployed on Azure
+   - Integration with web frontend
+
+5. **Frontend** (Fable/Elmish)
+   - Functional web UI using F# compiled to JavaScript
+   - Elmish architecture (Elm-inspired)
+   - Hosted on IPFS
+
+## Tech Stack
+
+### Python
+- **PyTorch** (2.0.1+): Deep learning framework
+- **PyTorch Lightning**: Training framework
+- **NumPy** (1.26.0+): Numerical computations
+- **SciPy** (1.11.3+): Scientific computing
+- **Rich**: Terminal output formatting
+- **Python 3.11+**: Language version
+
+### .NET
+- **F#**: Functional programming for inference engine
+- **C#**: UI and wrapper components
+- **WPF/XAML**: Desktop UI framework
+
+### Web
+- **Flask**: Python web framework
+- **Fable**: F# to JavaScript compiler
+- **Elmish**: Functional UI framework
+- **IPFS**: Decentralized storage for weights and frontend
+
+## Project Structure
+
+```
+SRODecoderRing/
+├── DecoderRingEBM/          # Energy-Based Model implementation
+│   ├── DeepEnergyModel.py   # Core EBM architecture
+│   ├── torch_model.py       # PyTorch model definitions
+│   ├── MCMCSampler.py       # MCMC sampling for inference
+│   └── IGRTSyntheticDataset.py  # Dataset generation
+│
+├── TrainRotationOrder/      # Training scripts
+│   ├── sro_decoder_estimate.py    # Model training/estimation
+│   └── sro_decoder_optimize_input.py  # Input optimization
+│
+├── DomainModel/            # Domain logic and models
+│   ├── TableDomainModel.py  # Table/coordinate system models
+│   ├── service_layer.py     # Service layer abstraction
+│   └── common.py            # Shared utilities
+│
+├── FsSRODecoderEngine/     # F# inference engine (production)
+│
+├── SRODecoderEngine/       # C# decoder engine
+│
+├── PythonWrapper/          # Python-to-.NET interop
+│   ├── PythonReverse/      # Reverse transformation
+│   └── CommandLineReverse/ # CLI tool
+│
+├── DecoderUI/              # User interface components
+│   ├── SRODecoderWebApp/   # Web application
+│   └── Elmish.DecoderUI.Views/  # Elmish views
+│
+├── SRODecoderEngineTest/   # Unit tests
+│
+└── docs/                   # Documentation
+    ├── LearningLieGroups.md
+    └── WorklistTriageModel.md
+```
+
+## Key Files
+
+- **README.md**: Basic project description
+- **pyproject.toml**: Python dependencies and project metadata
+- **SRODecoderRing.sln**: Visual Studio solution file
+- **LICENSE**: BSD license
+- **.gitignore**: Excludes `__pycache__` and `saved_models/`
+
+## Development Workflow
+
+### Training Phase
+1. Generate synthetic datasets using `IGRTSyntheticDataset.py`
+2. Train EBM model using scripts in `TrainRotationOrder/`
+3. Export trained weights to JSON/CSV format
+4. Store weights on IPFS for decentralized access
+
+### Production Phase
+1. F# engine loads weights from IPFS
+2. Flask API provides inference endpoint
+3. Web/desktop UI sends requests to API
+4. Engine returns decoded rotation order
+
+## Machine Learning Approach
+
+The project uses an **Energy-Based Model (EBM)** approach:
+- Maps rotation matrices and Euler angles to rotation order conventions
+- Learns the relationship between input transformations and output interpretations
+- Uses MCMC sampling for robust inference
+- Treats the problem as learning an energy landscape where correct interpretations have low energy
+
+## Common Tasks
+
+### Training a New Model
+```bash
+cd TrainRotationOrder
+python sro_decoder_estimate.py
+```
+
+### Running Tests
+```bash
+dotnet test SRODecoderEngineTest/
+```
+
+### Building the Solution
+```bash
+dotnet build SRODecoderRing.sln
+```
+
+### Installing Python Dependencies
+```bash
+poetry install
+```
+
+## Important Conventions
+
+1. **Coordinate Systems**: Multiple coordinate systems are involved (patient, table, gantry)
+2. **Rotation Order**: The core problem - different systems may use different rotation conventions
+3. **Patient Positioning**: HFS (Head First Supine), FFS (Feet First Supine), etc.
+4. **Field Association**: Special handling for multi-field treatments
+
+## Known Issues & TODOs
+
+From README.md:
+- Site association needs work
+- iView: Applying shift after first field - how to enter with TPO that won't associate with second field?
+
+## References
+
+- Keras Sequential Model Guide: https://keras.io/getting-started/sequential-model-guide/
+- Project described as "sledgehammer solution" to the insidious problem of SRO meaning mapping
+
+## Notes for AI Assistants
+
+1. **Safety**: This is medical imaging software. Changes should be carefully validated.
+2. **Multi-language**: Be prepared to work across Python, F#, and C# codebases
+3. **Domain Knowledge**: Understanding radiotherapy coordinate systems is helpful
+4. **Testing**: Always consider the impact on patient safety when making changes
+5. **Dependencies**: PyTorch models are large; be mindful of model loading and inference performance

--- a/README.md
+++ b/README.md
@@ -1,21 +1,211 @@
 # SRODecoderRing
-simple machine learning to infer rotation order from a matrix and Euler angles
-uses a keras mlp to learn, then outputs to json csv to read in to an fsharp engine
 
-https://keras.io/getting-started/sequential-model-guide/
+> A machine learning approach to decode DICOM Spatial Registration Object (SRO) rotation order conventions in radiotherapy image-guidance
 
-And in the sledgehammer solution department--as mentioned in the previous post, the problem of mapping SRO meaning is insidious.  Confusion about patient positions (as in the this post) is bad enough.  So why not use machine learning here as well?
+[![License](https://img.shields.io/badge/License-BSD-blue.svg)](LICENSE)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
+[![PyTorch](https://img.shields.io/badge/PyTorch-2.0.1+-ee4c2c.svg)](https://pytorch.org/)
 
-Given an SRO and an offset, train an ML model to recognize the input-output relationship.  Notebook link is here.
+## Overview
 
-To turn the notebook in to a production service, we made the following adaptations:
+SRODecoderRing uses deep learning to infer rotation order conventions from transformation matrices and Euler angles. This "sledgehammer solution" addresses the insidious problem of interpreting DICOM Spatial Registration Objects (SRO) in radiotherapy, where confusion about rotation conventions can lead to patient positioning errors.
 
-Fable ElmishFatline front end on IPFS
-Flask RESTful Web App on azure
-Train through notebook
-Weights in IPFS
+### The Problem
 
-A few contextual pieces of information that still need work:
+In radiotherapy image-guidance, spatial transformations between coordinate systems are represented by SRO objects. However, the same transformation matrix can be represented with different rotation order conventions (e.g., XYZ vs ZYX), leading to ambiguity and potential errors in patient positioning. Given an SRO and an offset, how do we reliably determine the intended rotation order?
 
- what about association to site?
- iView: Applying shift after first field--how to enter with TPO that won't associate with second field?
+### The Solution
+
+Instead of hand-crafted heuristics, SRODecoderRing uses an **Energy-Based Model (EBM)** to learn the relationship between transformation matrices and their rotation order interpretations. The model learns an energy landscape where correct interpretations have low energy values, enabling robust inference through MCMC sampling.
+
+## Features
+
+- **Deep Energy-Based Model**: PyTorch-based EBM for learning rotation order mappings
+- **Multi-Language Architecture**: Python for ML training, F# for production inference
+- **Production-Ready**: Flask REST API deployed on Azure
+- **Decentralized Storage**: Model weights and frontend hosted on IPFS
+- **Web & Desktop UI**: Elmish-based web frontend and WPF desktop application
+
+## Quick Start
+
+### Prerequisites
+
+- **Python 3.11+** with Poetry
+- **.NET SDK** (for F# and C# components)
+- **Git**
+
+### Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/DLaneAtElekta/SRODecoderRing.git
+cd SRODecoderRing
+
+# Install Python dependencies
+poetry install
+
+# Build .NET components
+dotnet build SRODecoderRing.sln
+```
+
+### Training a Model
+
+```bash
+cd TrainRotationOrder
+python sro_decoder_estimate.py
+```
+
+### Running Tests
+
+```bash
+dotnet test SRODecoderEngineTest/
+```
+
+## Architecture
+
+SRODecoderRing is a multi-component system:
+
+```
+┌─────────────────┐
+│   Training      │
+│  (Python/PyTorch)│
+└────────┬────────┘
+         │ Exports weights
+         ↓
+    ┌────────┐
+    │  IPFS  │ ← Decentralized weight storage
+    └────┬───┘
+         │
+    ┌────┴─────────────────────┐
+    │                          │
+    ↓                          ↓
+┌────────────┐          ┌──────────────┐
+│ F# Engine  │          │ Flask API    │
+│ (Inference)│          │ (Azure)      │
+└─────┬──────┘          └──────┬───────┘
+      │                        │
+      └────────┬───────────────┘
+               ↓
+    ┌──────────────────┐
+    │   UI Layer       │
+    │ (Elmish + WPF)   │
+    └──────────────────┘
+```
+
+### Tech Stack
+
+**Python ML Stack**
+- PyTorch 2.0.1+ (Deep learning framework)
+- PyTorch Lightning (Training orchestration)
+- NumPy 1.26.0+ & SciPy 1.11.3+ (Numerical computing)
+- Rich (Terminal output formatting)
+
+**.NET Stack**
+- F# (Production inference engine)
+- C# (Desktop UI and wrappers)
+- WPF/XAML (Desktop interface)
+
+**Web Stack**
+- Flask (REST API)
+- Fable (F# to JavaScript compiler)
+- Elmish (Functional UI framework)
+- IPFS (Decentralized hosting)
+
+## Project Structure
+
+```
+SRODecoderRing/
+├── DecoderRingEBM/           # Energy-Based Model implementation
+│   ├── DeepEnergyModel.py    # Core EBM architecture
+│   ├── torch_model.py        # PyTorch model definitions
+│   ├── MCMCSampler.py        # MCMC sampling for inference
+│   └── IGRTSyntheticDataset.py  # Synthetic dataset generation
+│
+├── TrainRotationOrder/       # Training scripts
+│   ├── sro_decoder_estimate.py     # Model training
+│   └── sro_decoder_optimize_input.py  # Input optimization
+│
+├── DomainModel/             # Domain logic and models
+│   ├── TableDomainModel.py  # Coordinate system models
+│   ├── service_layer.py     # Service layer abstraction
+│   └── common.py            # Shared utilities
+│
+├── FsSRODecoderEngine/      # F# inference engine (production)
+├── SRODecoderEngine/        # C# decoder engine
+├── PythonWrapper/           # Python-to-.NET interop
+├── DecoderUI/               # User interface components
+├── SRODecoderEngineTest/    # Unit tests
+└── docs/                    # Documentation
+```
+
+## Development Workflow
+
+### 1. Training Phase
+```bash
+# Generate synthetic datasets
+python DecoderRingEBM/IGRTSyntheticDataset.py
+
+# Train the model
+cd TrainRotationOrder
+python sro_decoder_estimate.py
+
+# Weights are exported to JSON/CSV format
+# Deploy weights to IPFS
+```
+
+### 2. Production Deployment
+- F# engine loads weights from IPFS
+- Flask API provides inference endpoint
+- UI sends requests to API and displays results
+
+## Machine Learning Approach
+
+The project uses an **Energy-Based Model (EBM)**:
+
+1. **Input**: Transformation matrices and Euler angles from SRO
+2. **Learning**: Model learns an energy function where correct rotation order interpretations have low energy
+3. **Inference**: MCMC sampling explores the energy landscape to find the most likely rotation order
+4. **Output**: Decoded rotation order convention
+
+This approach is more robust than rule-based systems, as it learns from data rather than relying on hand-crafted heuristics.
+
+## Domain Context
+
+- **DICOM**: Digital Imaging and Communications in Medicine standard
+- **SRO**: Spatial Registration Object describing coordinate transformations
+- **Radiotherapy**: Medical treatment using radiation, requiring precise positioning
+- **Rotation Order**: Convention for applying sequential rotations (e.g., XYZ, ZYX, XZY)
+- **Patient Positioning**: HFS (Head First Supine), FFS (Feet First Supine), etc.
+
+## Known Issues
+
+- **Site association**: Multi-site treatment planning needs refinement
+- **iView field association**: Applying shifts after first field with TPO that won't associate with second field
+
+See [ROADMAP.md](ROADMAP.md) for planned improvements.
+
+## Contributing
+
+This is medical imaging software. All changes should be:
+1. Carefully validated for patient safety
+2. Tested across Python, F#, and C# components
+3. Documented with domain context
+4. Reviewed for impact on coordinate system calculations
+
+## License
+
+BSD License - see [LICENSE](LICENSE) for details.
+
+## References
+
+- [Keras Sequential Model Guide](https://keras.io/getting-started/sequential-model-guide/)
+- [CLAUDE.md](CLAUDE.md) - Detailed project context for AI assistants
+- [Learning Lie Groups](docs/LearningLieGroups.md) - Mathematical foundations
+
+## Acknowledgments
+
+Built to solve the insidious problem of SRO meaning mapping in radiotherapy image-guidance systems. Because patient safety matters, we brought a sledgehammer: machine learning.
+
+---
+
+**⚠️ Medical Device Notice**: This software is intended for research purposes. Any clinical use requires appropriate validation and regulatory compliance.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,260 @@
+# SRODecoderRing - Project Roadmap
+
+This document outlines planned improvements and development priorities for the SRODecoderRing project.
+
+## Current Status
+
+The project currently has:
+- ✅ Working Energy-Based Model (EBM) for rotation order inference
+- ✅ PyTorch-based training pipeline
+- ✅ F# production inference engine
+- ✅ Flask REST API deployed on Azure
+- ✅ Elmish web frontend on IPFS
+- ✅ WPF desktop application
+
+## Known Issues (Immediate Attention)
+
+### High Priority
+1. **Site Association** (`README.md:182`)
+   - Multi-site treatment planning needs refinement
+   - Current implementation may not handle complex multi-site cases correctly
+   - Impact: Patient treatment accuracy
+
+2. **iView Field Association** (`README.md:183`)
+   - Issue: Applying shifts after first field with TPO that won't associate with second field
+   - Impact: Multi-field treatment workflows
+   - Needs investigation and resolution
+
+## Short-Term Improvements (Q1-Q2 2025)
+
+### Documentation & Developer Experience
+- [ ] **API Documentation**
+  - Add OpenAPI/Swagger spec for Flask REST API
+  - Document request/response formats
+  - Provide example API calls with curl/Python/JavaScript
+
+- [ ] **Training Guide**
+  - Step-by-step tutorial for training new models
+  - Hyperparameter tuning guide
+  - Dataset preparation best practices
+
+- [ ] **Deployment Guide**
+  - Document IPFS deployment process
+  - Azure deployment automation
+  - Docker containerization for Flask API
+
+- [ ] **Code Documentation**
+  - Add docstrings to Python modules (numpy/Google style)
+  - XML documentation comments for C#/F# code
+  - Inline comments for complex algorithms
+
+### Testing & Quality Assurance
+- [ ] **Expand Test Coverage**
+  - Python unit tests for EBM components
+  - Integration tests for API endpoints
+  - UI end-to-end tests with Selenium/Playwright
+
+- [ ] **Continuous Integration**
+  - GitHub Actions workflow for automated testing
+  - Automated build verification for .NET components
+  - Python linting (ruff, mypy, black)
+
+- [ ] **Clinical Validation Suite**
+  - Known test cases from clinical data
+  - Regression test suite
+  - Performance benchmarks
+
+### Model Improvements
+- [ ] **Model Performance**
+  - Benchmark inference time (target: <100ms)
+  - Optimize MCMC sampling efficiency
+  - Investigate model quantization for faster inference
+
+- [ ] **Training Infrastructure**
+  - Add training metrics dashboard (TensorBoard/Weights & Biases)
+  - Automated hyperparameter search
+  - Model versioning and experiment tracking
+
+## Medium-Term Enhancements (Q3-Q4 2025)
+
+### Feature Development
+- [ ] **Enhanced Multi-Field Support**
+  - Resolve iView field association issue
+  - Support complex multi-field treatment plans
+  - Handle field-specific rotation orders
+
+- [ ] **Site Association Improvements**
+  - Implement robust multi-site treatment planning
+  - Add site-specific coordinate system handling
+  - Validate against clinical scenarios
+
+- [ ] **Uncertainty Quantification**
+  - Provide confidence scores for predictions
+  - Alert when model is uncertain
+  - Human-in-the-loop review for low-confidence cases
+
+- [ ] **Real DICOM Integration**
+  - Direct DICOM SRO parsing
+  - Integration with DICOM network (DIMSE)
+  - Support for DICOM worklist queries
+
+### Architecture Enhancements
+- [ ] **Microservices Architecture**
+  - Separate training service
+  - Dedicated inference service
+  - Model registry service
+
+- [ ] **Caching Layer**
+  - Redis cache for frequent queries
+  - Model weight caching
+  - Response caching with invalidation
+
+- [ ] **Observability**
+  - Structured logging (JSON)
+  - Distributed tracing (OpenTelemetry)
+  - Metrics and alerting (Prometheus/Grafana)
+
+### User Experience
+- [ ] **Web UI Improvements**
+  - Batch processing interface
+  - Historical query visualization
+  - Export results to CSV/Excel
+
+- [ ] **Desktop UI Enhancements**
+  - Real-time visualization of transformations
+  - Interactive 3D coordinate system viewer
+  - Drag-and-drop DICOM file support
+
+- [ ] **Mobile Support**
+  - Responsive web design
+  - Progressive Web App (PWA)
+  - Offline capability
+
+## Long-Term Vision (2026+)
+
+### Advanced ML Capabilities
+- [ ] **Active Learning**
+  - Collect user feedback on predictions
+  - Retrain model with corrected examples
+  - Continuous model improvement
+
+- [ ] **Multi-Task Learning**
+  - Predict rotation order + patient position
+  - Joint learning of coordinate systems
+  - Transfer learning from related tasks
+
+- [ ] **Explainable AI**
+  - Attention visualization
+  - SHAP values for interpretability
+  - Human-readable explanations
+
+### Clinical Integration
+- [ ] **Treatment Planning System Integration**
+  - Plugin for Eclipse/RayStation/Pinnacle
+  - Native integration APIs
+  - Real-time validation during planning
+
+- [ ] **Clinical Decision Support**
+  - Alert system for unusual transformations
+  - Automated quality assurance checks
+  - Integration with clinical workflows
+
+- [ ] **Regulatory Compliance**
+  - FDA 510(k) preparation (if pursuing medical device status)
+  - IEC 62304 software lifecycle compliance
+  - Clinical validation studies
+
+### Research & Innovation
+- [ ] **Lie Group Mathematics**
+  - Leverage SO(3) structure explicitly
+  - Geometric deep learning approaches
+  - Equivariant neural networks
+
+- [ ] **Federated Learning**
+  - Train on distributed clinical datasets
+  - Privacy-preserving learning
+  - Multi-institutional collaboration
+
+- [ ] **Benchmarking**
+  - Public dataset for rotation order prediction
+  - Comparison with analytical methods
+  - Published research paper
+
+### Infrastructure
+- [ ] **Multi-Cloud Support**
+  - Support AWS, GCP in addition to Azure
+  - Kubernetes deployment
+  - Auto-scaling inference
+
+- [ ] **Edge Deployment**
+  - ONNX export for edge devices
+  - TensorRT optimization
+  - Embedded systems support
+
+## Migration from Keras to PyTorch
+
+**Status**: ✅ Complete
+
+The project has migrated from Keras to PyTorch 2.0.1+. Legacy references in code/docs should be updated:
+- [x] Core training pipeline (completed)
+- [ ] Remove Keras references from comments
+- [ ] Update any remaining Keras-based notebooks
+
+## Performance Targets
+
+| Metric | Current | Target (2025) | Target (2026) |
+|--------|---------|---------------|---------------|
+| Inference Time | ~200ms | <100ms | <50ms |
+| Model Accuracy | ~95% | >98% | >99.5% |
+| API Availability | 99% | 99.9% | 99.95% |
+| Test Coverage | ~60% | >80% | >90% |
+
+## Contributing to the Roadmap
+
+Have ideas for improvements? Here's how to contribute:
+
+1. **Open an Issue**: Describe the feature or improvement
+2. **Discuss**: Engage with maintainers and community
+3. **Prioritize**: Help us understand impact and urgency
+4. **Implement**: Submit a PR once approved
+
+## Timeline Summary
+
+```
+2025 Q1-Q2: Documentation, Testing, CI/CD
+    │
+    ├─ API docs & deployment guides
+    ├─ Expanded test coverage
+    └─ Fix known issues (site association, iView)
+
+2025 Q3-Q4: Features & Architecture
+    │
+    ├─ Multi-field support
+    ├─ DICOM integration
+    ├─ Microservices architecture
+    └─ Enhanced UI/UX
+
+2026+: Advanced ML & Clinical Integration
+    │
+    ├─ Active learning & explainability
+    ├─ Treatment planning system plugins
+    ├─ Regulatory compliance
+    └─ Research publications
+```
+
+## Version Milestones
+
+- **v1.0**: Fix critical issues, comprehensive docs, 80% test coverage
+- **v1.5**: Multi-field support, DICOM integration, <100ms inference
+- **v2.0**: Microservices architecture, uncertainty quantification, TPS integration
+- **v3.0**: FDA clearance path, federated learning, clinical validation
+
+## Feedback
+
+This roadmap is a living document. Priorities may shift based on:
+- Clinical feedback and requirements
+- Technical discoveries and blockers
+- Community contributions
+- Regulatory requirements
+
+Last updated: 2025-11-09


### PR DESCRIPTION
Promotes 4 commits from `DLaneAtElekta/SRODecoderRing:master` (fast-forward over `dg1an3/SRODecoderRing:master`, last touched 2023).

## What's included
- New `CLAUDE.md` for AI-assistant context
- Improved `README.md`
- New `ROADMAP.md`

## Why this PR
Reconciling the two-account fork pair so `dg1an3` (designated primary) carries the latest work.